### PR TITLE
fix: outdate method of creating utc timestamps

### DIFF
--- a/asyncpool/__init__.py
+++ b/asyncpool/__init__.py
@@ -2,8 +2,7 @@ import asyncio
 from datetime import datetime, timezone
 
 def utc_now():
-    # utcnow returns a naive datetime, so we have to set the timezone manually <sigh>
-    return datetime.utcnow().replace(tzinfo=timezone.utc)
+    return datetime.now(tz=timezone.utc)
 
 class Terminator:
     pass


### PR DESCRIPTION
This fixes the usage of replace with `utcnow` with the recommendation from https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow